### PR TITLE
Use subscribers_count instead of watchers_count

### DIFF
--- a/_plugins/plugin_pages.rb
+++ b/_plugins/plugin_pages.rb
@@ -338,7 +338,7 @@ module Jekyll
         'language' => repo['language'],
         'private' => repo['private'],
         'stargazers' => repo['stargazers_count'],
-        'watchers' => repo['watchers_count'],
+        'watchers' => repo['subscribers_count'],
         'contributors' => get_repo_contributors(repo),
         'license_id' => !repo['license'].nil? ? repo['license']['spdx_id'] : nil,
         'license_name' => !repo['license'].nil? ? repo['license']['name'] : nil,


### PR DESCRIPTION
watchers_count refers to stargazers too, refering to https://github.com/PyGithub/PyGithub/issues/367
subscribers_count instead contains the amount of people watching/subscribed to the repositiory.